### PR TITLE
updated the path for the course notes

### DIFF
--- a/scripts/egghead-course-notes.js
+++ b/scripts/egghead-course-notes.js
@@ -27,7 +27,7 @@ let { name: course } = await arg(
 
 //! Loads individual course notes
 //! expects notes to be in a `/notes` subfolder!
-let notesContent = await getCourseNotesContentByPath(`${course}/notes`);
+let notesContent = await getCourseNotesContentByPath(`courses/${course}/notes`);
 
 let getCourseNotesFolder = async () => {
   await run(kenvPath("kenvs", "egghead", "scripts", "egghead-course-notes.js"));
@@ -40,7 +40,7 @@ let getNote = async () => {
   );
 
   let { content, encoding } = await getCourseNotesContentByPath(
-    `${course}/notes/${fileName}`
+    `courses/${course}/notes/${fileName}`
   );
 
   return Buffer.from(content, encoding).toString();
@@ -51,7 +51,7 @@ let viewNote = async () => {
 };
 
 let createCdnLink = (slug) =>
-  `https://cdn.jsdelivr.net/gh/eggheadio/eggheadio-course-notes/${course}/notes/${slug}`;
+  `https://cdn.jsdelivr.net/gh/eggheadio/eggheadio-course-notes/courses/${course}/notes/${slug}`;
 
 let postNote = async (url, noteCdn) => {
   await put(


### PR DESCRIPTION
Updated the path for the course notes since I updated the egghead-course-notes repo.

![](https://media2.giphy.com/media/A7WYEfDF6Li8O49gEP/giphy.gif?cid=5a38a5a2pqwg2e1engjqlajnc3zz8xg438zosetby6xub6by&rid=giphy.gif&ct=g)